### PR TITLE
fix(wine): add Linux and Wine support

### DIFF
--- a/src/patcher/DllMonitor.cpp
+++ b/src/patcher/DllMonitor.cpp
@@ -435,30 +435,40 @@ void DllMonitor::HandleUnload(const std::wstring& matched)
     OutputDebugStringW(std::format(L"HandleUnload for {}\n", matched).c_str());
 #endif
 
-    std::lock_guard lk(m_statesMutex);
-    auto it = m_states.find(matched);
-    if (it == m_states.end())
-        return;
-
-    TargetState& st = it->second;
+    TargetState* state = nullptr;
     {
-        std::lock_guard lk2(m_targetsMutex);
-        auto it2 = m_targets.find(matched);
-        if (it2 != m_targets.end() && it2->second.onUnloaded)
-        {
-            it2->second.onUnloaded(st);
-        }
+        std::lock_guard lk(m_statesMutex);
+        auto it = m_states.find(matched);
+        if (it == m_states.end())
+            return;
+
+        state = &it->second;
     }
 
-    // The module is on its way out, so don't write its entry point back.
-    ReleaseHook(st.base, false);
+    TargetInfo target;
+    {
+        std::lock_guard lk(m_targetsMutex);
+        auto it = m_targets.find(matched);
+        if (it != m_targets.end())
+            target = it->second;
+    }
 
-    m_states.erase(it);
+    const uintptr_t base = state->base;
+
+    if (target.onUnloaded)
+        target.onUnloaded(*state);
+
+    // The module is on its way out, so don't write its entry point back.
+    ReleaseHook(base, false);
+
+    std::lock_guard lk(m_statesMutex);
+    m_states.erase(matched);
 }
 
 void DllMonitor::NotifyUnpacked(uintptr_t base)
 {
-    bool handled = false;
+    std::wstring matched;
+    TargetState* state = nullptr;
 
     {
         std::lock_guard lk(m_statesMutex);
@@ -469,24 +479,30 @@ void DllMonitor::NotifyUnpacked(uintptr_t base)
                 continue;
 
             st.unpacked = true;
-            handled = true;
-
-            std::lock_guard lk2(m_targetsMutex);
-            auto it = m_targets.find(key);
-            if (it != m_targets.end() && it->second.onLoaded)
-            {
-                if (it->second.onLoaded(st, st.base, st.size, st.fullPath))
-                    st.active = true;
-            }
+            matched = key;
+            state = &st;
 
             break;
         }
     }
 
+    if (!state)
+        return;
+
+    TargetInfo target;
+    {
+        std::lock_guard lk(m_targetsMutex);
+        auto it = m_targets.find(matched);
+        if (it != m_targets.end())
+            target = it->second;
+    }
+
+    if (target.onLoaded && target.onLoaded(*state, state->base, state->size, state->fullPath))
+        state->active = true;
+
     // The entry point is DllMain, re-entered on every DLL_THREAD_ATTACH. It
     // only needs unpacking once, so let every later call go straight through.
-    if (handled)
-        UnhookEntryPointFor(base);
+    UnhookEntryPointFor(base);
 }
 
 bool DllMonitor::TryMatchTargets(const std::wstring& moduleBaseName, std::wstring& outMatchedPart)

--- a/src/patcher/DllMonitor.h
+++ b/src/patcher/DllMonitor.h
@@ -57,6 +57,10 @@ private:
         PVOID context);
 
 private:
+    // Neither mutex is held across an onLoaded/onUnloaded callback: hashing a
+    // module loads the crypto providers, and every load re-enters
+    // DllNotification on this thread, where re-taking one would throw.
+
     // lowercase name part -> TargetInfo
     std::mutex m_targetsMutex;
     std::unordered_map<std::wstring, TargetInfo> m_targets;


### PR DESCRIPTION
While trying your custom DLL on my OS (ZorinOS) with Wine, I encountered crashes with both provided DLL.

Working with Claude, I was able to make it work with this minimal set of changes. It shouldn't break anything on Windows but I can't test it. Please let me know if you need anything or if any adjustment is needed on this work. You can also use the reported information about the crashes and provide a fix yourself if you are more comfortable with your own code. In any case, I can test anything you need on my end if needed, just let me know what. :)

The fix is tested and is confirmed working on Linux with Wine.

I'd be glad if you'd consider merging this and publish a new release including this fix. I think Linux support is crucial for the long term survival of the Sudden Strike series. :)

Below are the explanations provided by Claude Opus.

## TL;DR

Under Wine, MultiCAD killed the game the moment a mission started. Two different symptoms, one bug:

| Build             | Symptom                                                                                                                             |
| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
| `cadMulti.dll`    | process aborts instantly: `wine: Call from 7B6567A7 to unimplemented function msvcp140.dll.?_Throw_Cpp_error@std@@YAXH@Z, aborting` |
| `cadMulti_mt.dll` | game pops `VStart Error` — `Can't load Game_Dll.dll: -529697949` — and drops back to the menu                                       |

`DllMonitor::NotifyUnpacked()` invoked `onLoaded` **while holding both `m_statesMutex` and `m_targetsMutex`**. `InstallGamePatches()` hashes the game dll with CryptoAPI, and `CryptAcquireContext()` _loads_ `bcrypt` / `crypt32` / `rsaenh`. Every one of those loads re-enters `DllMonitor::DllNotification` **on the same thread**, which locks `m_targetsMutex` again. MSVC's `std::mutex` detects the recursive lock and throws `system_error(resource_deadlock_would_occur)`, which escapes `Game_Dll.dll`'s `DllMain`.

Windows never hits it because it keeps the crypto providers loaded between `CryptAcquireContext` calls, so the second one (game dll, after the menu dll) loads nothing and fires no nested notification. Wine unloads them, so the second call reloads all three.

The fix is to run the `onLoaded` / `onUnloaded` callbacks unlocked — the shape `HandleLoad()` already uses. Two files, no behavioural change on Windows.

---

## Technical details

### What actually happens

Wine relay trace of the mission start (`cadMulti_mt.dll`, HS2 Fusion 4.1b + APRM, wine-10.0, WOW64):

```
Call PE DLL (proc=0436D10B, module=032B0000 L"Game_Dll.dll", reason=PROCESS_ATTACH)
  Call KERNEL32.VirtualProtect(032b0780,00000880,00000004,...)   <- Petite unpacking
  Call KERNEL32.VirtualProtect(032b0780,00000880,00000002,...)
  Call KERNEL32.CreateThread(...)              ret=1d005f07      <- AudioHelper std::thread
  Call advapi32.CryptAcquireContextW(...)      ret=1cfea1e8      <- DllVersionDetector::AnalyzeDll
  Loaded L"C:\windows\system32\bcrypt.dll"
  Loaded L"C:\windows\system32\crypt32.dll"
  Loaded L"C:\windows\system32\rsaenh.dll"
  Call LDR notification callback (proc=1CFE6650, reason=1, ...)  <- nested; never returns
  exception e06d7363 in PE entry point
Ret  PE DLL (...) retval=0
Call PE DLL (... reason=PROCESS_DETACH)
Call user32.MessageBoxA(..., "Can't load Game_Dll.dll: -529697949\n", "VStart Error", ...)
```

`0xE06D7363` is the MSVC C++ exception code; `-529697949` is the same value the game prints as a signed int. `1CFE6650` is `DllMonitor::DllNotification` inside `cadMulti_mt.dll` (base `1CFC0000`).

The nested callback does exactly one thing before it throws — `TryMatchTargets()`:

```cpp
std::lock_guard lk(m_targetsMutex);   // already owned by this thread
```

Disassembly of `TryMatchTargets` in the release build confirms the site:

```asm
1002655b:  mov  -0x30(%ebp),%ebx        ; this
1002655e:  push %ebx
10026562:  call 0x1003af44              ; _Mtx_lock(&m_targetsMutex)
1002656a:  test %eax,%eax
1002656c:  jne  0x10026638
...
10026638:  push $0x5                    ; _RESOURCE_DEADLOCK_WOULD_OCCUR
1002663a:  call 0x1003aee6              ; std::_Throw_Cpp_error
```

`bcrypt` / `crypt32` / `rsaenh` don't match any registered target, so the throw happens on the very first statement of the nested callback — before it can even decide there's nothing to do.

### Why Windows is fine and Wine is not

Same trace, earlier — the menu dll gets hashed first, and Wine drops the providers the moment `CryptReleaseContext` runs:

```
Call advapi32.CryptAcquireContextW(...)  ret=1cfea1e8
  Loaded   bcrypt.dll / crypt32.dll / rsaenh.dll
Ret  advapi32.CryptAcquireContextW() retval=00000001
  Unloaded rsaenh.dll / crypt32.dll / bcrypt.dll     <-- Wine only
```

On Windows those stay resident, so by the time `InstallGamePatches()` runs there is nothing left to load and no nested notification. Nothing about the mod is Wine-specific — Wine just exposes a latent re-entrancy bug that Windows' module caching hides. Any Windows machine where `rsaenh` happened not to be resident yet would hit the same thing.

The menu dll never trips it either, because it is unpacked: `HandleLoad()` copies the `TargetInfo` under the lock, releases, _then_ calls `onLoaded`. Only the packed path (`NotifyUnpacked`, reached from the Petite entry-point hook) kept the locks held.

### Why the two builds fail differently

`_Throw_Cpp_error` lives in `msvcp140.dll`, which Wine implements as a **stub** for that export. So `cadMulti.dll` doesn't get an exception at all — Wine terminates the process on the call. `cadMulti_mt.dll` links the CRT statically, so the throw is real, unwinds out of `DllMain`, and `LoadLibrary` fails with the exception code. Same root cause, two faces.

### The change

`NotifyUnpacked()` — collect what's needed under the locks, release, then call:

```cpp
    if (!state)
        return;

    TargetInfo target;
    {
        std::lock_guard lk(m_targetsMutex);
        auto it = m_targets.find(matched);
        if (it != m_targets.end())
            target = it->second;
    }

    if (target.onLoaded && target.onLoaded(*state, state->base, state->size, state->fullPath))
        state->active = true;

    UnhookEntryPointFor(base);
```

`HandleUnload()` had the identical shape (`onUnloaded` under both locks) and is fixed the same way. It hasn't been observed to fire — none of the current unload paths load a module — but it's the same latent defect and would be the next one to bite.

`Shutdown()` also calls `onUnloaded` under both locks and is deliberately left alone: it unregisters the notification callback first, so nothing can re-enter.

### Why this is safe for Windows

- No callback is added, removed or reordered.
- `UnhookEntryPointFor()` runs in exactly the same cases as before (`state != nullptr` replaces the old `handled` flag; a missing `m_targets` entry skipped `onLoaded` and still unhooked, and still does).
- In `HandleUnload()` the `onUnloaded` → `ReleaseHook` → `erase` order is unchanged; the erase is now by key rather than by iterator, which is what re-locking requires.
- The `TargetState*` held across the unlocked window stays valid: `m_states` is an `unordered_map`, so only erasing that element invalidates it, and erasure only happens on the loader thread that is currently inside the callback.
- This does not widen the concurrency exposure: `HandleLoad()` has always run `onLoaded` with no lock held.

On Windows, where no nested load occurs, the observable behaviour is identical.

### Verification

Environment: Zorin OS, wine-10.0 (WOW64, X11, 1920x1080), fresh HS2 Fusion 4.1b prefix, `Game_Dll.dll` + `Menu_dll.dll` both correctly identified as `GameVersion::HS_2`.

- **Before** — mission start dies as described, with both `cadMulti.dll` and `cadMulti_mt.dll`. The stock `n2Cad800.dll` runs fine, so the environment itself is sound.
- **Root cause proof** — patching _only_ the `push $0x5 / call _Throw_Cpp_error` branch in a copy of the compiled `cadMulti_mt.dll` so the recursive lock returns "no match" (which is exactly what the fixed code produces for those three dlls) makes the mission load and run at **1920x1080**, with zero `loader_section` warnings.
- **Source** — the two rewritten methods were compile-checked in isolation. The MSVC build itself has **not** been built or run yet; a Windows regression pass and a rebuilt-DLL run on Wine are still needed.

Display handling under Wine was verified separately and is not a problem: `EnumDisplaySettingsA(ENUM_REGISTRY_SETTINGS)` returns the real desktop mode (1920x1080), `IDirectDraw::EnumDisplayModes` lists `1920x1080x16`, and `SetDisplayMode` succeeds.
