### PR TITLE
fix(patcher): ensure multiplier zeppelins functionality by updating strategic map overlay handling

### DIFF
--- a/src/patcher/GameDllHooks.cpp
+++ b/src/patcher/GameDllHooks.cpp
@@ -2577,6 +2577,7 @@ void __declspec(noinline) __fastcall GameDllHooks::sub_100ACDE0(UiStrategicMapEl
         g->getFn<void(__thiscall)(UiElementBase*, int, int, int, int16_t)>(0xAC790),
         g->getFn<void(__thiscall)(UiElementBase*, int, int, int, int16_t)>(0xAC800),
         g->getFn<void(__stdcall)(int, int, int)>(0xC3420),
+        g->getValue<uintptr_t*>(0x106F69C),
         g->getValue<UnitData*>(0x10F258),
         105,
         g->getValue<int16_t>(0x106F12E),
@@ -2604,6 +2605,7 @@ void __declspec(noinline) __fastcall GameDllHooks::sub_100A9060_v2_3(UiStrategic
         g->getFn<void(__thiscall)(UiElementBase*, int, int, int, int16_t)>(0xA8A10),
         g->getFn<void(__thiscall)(UiElementBase*, int, int, int, int16_t)>(0xA8A80),
         g->getFn<void(__stdcall)(int, int, int)>(0xBE2D0),
+        g->getValue<uintptr_t*>(0x10AEA74),
 
         g->getValue<UnitData*>(0xFCC90),
         113,
@@ -2634,6 +2636,7 @@ void __declspec(noinline) __fastcall GameDllHooks::sub_100A9060_v2_4(UiStrategic
         g->getFn<void(__thiscall)(UiElementBase*, int, int, int, int16_t)>(0xA8A10),
         g->getFn<void(__thiscall)(UiElementBase*, int, int, int, int16_t)>(0xA8A80),
         g->getFn<void(__stdcall)(int, int, int)>(0xBE2E0),
+        g->getValue<uintptr_t*>(0x10AEA74),
 
         g->getValue<UnitData*>(0xFCC90),
         113,
@@ -2663,6 +2666,7 @@ void __declspec(noinline) __fastcall GameDllHooks::sub_100A9060_bg(UiStrategicMa
         g->getFn<void(__thiscall)(UiElementBase*, int, int, int, int16_t)>(0xA89E0),
         g->getFn<void(__thiscall)(UiElementBase*, int, int, int, int16_t)>(0xA8A50),
         g->getFn<void(__stdcall)(int, int, int)>(0xBE2B0),
+        nullptr,
         g->getValue<UnitData*>(0xFCE40),
         113,
         g->getValue<int16_t>(0x109E6B6),
@@ -3460,24 +3464,20 @@ void GameDllHooks::drawFogOnStrategicMap(UiStrategicMapElement* mapData, const F
         static_cast<int>(scale)
     );
 
-    // This code always calls stubs
-    /*
-    const int* dword_1106F69C = g->getValue<int*>(0x106F69C);
+    if (data.strategicMapOverlay)
+    {
+        const uintptr_t overlayVtable = *data.strategicMapOverlay;
+        const uintptr_t drawOverlay = *reinterpret_cast<uintptr_t*>(overlayVtable + 56);
+        const uint64_t scaleBits = *reinterpret_cast<const uint64_t*>(&scale2);
 
-    const uintptr_t objAddr = static_cast<uintptr_t>(*dword_1106F69C);
-    const uintptr_t funcAddr = *reinterpret_cast<uintptr_t*>(objAddr + 56);
-
-    const uint64_t bits = *reinterpret_cast<const uint64_t*>(&scale2);
-    const uint32_t lo = static_cast<uint32_t>(bits & 0xFFFFFFFF);
-    const uint32_t hi = static_cast<uint32_t>(bits >> 32);
-
-    reinterpret_cast<void(__stdcall*)(int, int, uint32_t, uint32_t)>(funcAddr)(
-        mapData->screenSurfaceWidth / 2,
-        mapData->verticalCenterMargin,
-        lo,
-        hi
+        reinterpret_cast<void(__thiscall*)(uintptr_t*, int, int, uint32_t, uint32_t)>(drawOverlay)(
+            data.strategicMapOverlay,
+            mapData->screenSurfaceWidth / 2,
+            mapData->verticalCenterMargin,
+            static_cast<uint32_t>(scaleBits),
+            static_cast<uint32_t>(scaleBits >> 32)
         );
-    */
+    }
 
     // Draw units points
     // It also shows building occupied by enemy as red dot even if we don't know that the building is occupied by them

--- a/src/patcher/GameDllHooks.h
+++ b/src/patcher/GameDllHooks.h
@@ -1098,6 +1098,7 @@ private:
         void(__thiscall* drawHorLine)(UiElementBase*, int, int, int, int16_t);
         void(__thiscall* drawVertLine)(UiElementBase*, int, int, int, int16_t);
         void(__stdcall* drawPlaneCrosses)(int, int, int);
+        uintptr_t* strategicMapOverlay;
 
         UnitData* units;
         int unitVtableOffset;


### PR DESCRIPTION
## Summary

Restores zeppelin markers and their ownership indicators on the strategic map opened with M.

Fixes #6.

## Root cause

MultiCAD’s replacement strategic-map renderer skipped a virtual overlay-rendering callback used for zeppelin markers. The callback requires the overlay object in `ECX` because it uses the `__thiscall` calling convention.

## Changes

- Resolve the strategic-map overlay object for supported game versions.
- Invoke its virtual rendering callback after plane crosses are drawn.
- Pass the overlay object using the correct `__thiscall` ABI.
- Guard the callback when no verified overlay address is available, including Black Gold.

## Validation

- Built `cadMulti_mt.dll` successfully.
- Confirmed manually under Wine at `1920x1080`.
- Zeppelin dots and ownership indicators appear correctly.